### PR TITLE
Sanitize hints from references

### DIFF
--- a/src/wiki.js
+++ b/src/wiki.js
@@ -55,6 +55,7 @@ const WikiPage = class WikiPage {
         .filter((i, el) => cheerio(el).text().trim() !== '')
         .first()
         .text()
+        .replace(/\[\d+]/gm, '')
       return hint.length > HINT_LENGTH
         ? `${hint.substr(0, HINT_LENGTH)}…`
         : hint


### PR DESCRIPTION
Delete all occurrences of more than one digit enclosed in square brackets; fixes #160. 

I've looked at some random articles and didn't find anything that could be removed as well. Pronunciation in IPA maybe? Let me know if you know something to remove and I'll be glad to add it to the PR, otherwise if you're fine with it, just merge it. 🙂 