### PR TITLE
Only show backlinks which are no redirects

### DIFF
--- a/src/wiki.js
+++ b/src/wiki.js
@@ -74,7 +74,7 @@ const WikiPage = class WikiPage {
       format: 'json',
       list: 'backlinks',
       bltitle: this.title,
-      blfilterredir: 'all',
+      blfilterredir: 'nonredirects',
       blnamespace: 0,
       bllimit: BACKLINKS_LIMIT
     })


### PR DESCRIPTION
This will prevent the following (fictional but possible) scenario:
Goal: Wikirace
Backlinks:
 - Wikiwars
 - Wiki Wars
 - Wikipedia challenge
 - Wikipedia race
 - Wikipedia Race
...